### PR TITLE
Alternate method for switching tabs

### DIFF
--- a/shortcuts
+++ b/shortcuts
@@ -14,8 +14,8 @@
 // command + t : create new tab
 // command + w : close tab
 // command + q : quit application
-// command + shift + ] : move right one tab
-// command + shift + [ : move left one tab
+// command + shift + ] : move right one tab   OR   command + opt + -->   (Chrome and Sublime)
+// command + shift + [ : move left one tab    OR   command + opt + <--   (Chrome and Sublime) 
 // command + NUMBER : move to tab number NUMBER
 
 // Random:


### PR DESCRIPTION
I tend to use the cmd + opt + arrow keys to quickly move around tabs in Chrome and Sublime. All of the buttons are right next to each other, allowing for easy, quick cruising. However, this shortcut does NOT work in Terminal. 
(Also, I'm just practicing pull requests.)