### PR TITLE
Added shortcut to select address bar in Chrome

### DIFF
--- a/shortcuts.js
+++ b/shortcuts.js
@@ -46,6 +46,7 @@
 // command + ] : move forward through history
 // command + [ : move backward through history
 // command + shift + t : reopen last closed tab (up to 10)
+// command + l : select address bar
 
 // Sublime:
 // command + ctrl + f : toggle fullscreen


### PR DESCRIPTION
Cmd + L (or Ctrl + L) selects the text in the address bar in Chrome for quick editing. This was the only addition.