### PR TITLE
Add multi-line comment shortcut for Sublime

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ You can use Alfred to
 
 `command + /` : toggle comment for line
 
+`command + option + /` : toggle multi-line comment for selected lines, or open empty multi-line comment
+
 `command + ]` : shift indenting right
 
 `command + [` : shift indenting left


### PR DESCRIPTION
Holding `option` modifies the Sublime shortcut for commenting a line and causes it to open a syntax-correct multi-line comment block. This commit adds this shortcut to the repository