### PR TITLE
Add cmd+shift+a shortcut to expand content to entire HTML element

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ You can use Alfred to
 
 `command + d` : select word(s)
 
+`command + shift + a` : expand selection to entire HTML element
+
 `command + k` while selecting words : don't select word
 
 `command + ctrl + g` : select all of words


### PR DESCRIPTION
Added shortcut to expand content to entire element. Say you want to delete all the content in your <body> tag. Simply have your cursor in your <body> tag and use the cmd+shift+a shortcut to select everything inside of that body tag. Works for every other tag as well. Also, when you use this shortcut inside of an element, it automatically selects everything in the tag that your cursor was on.